### PR TITLE
Don't explicitly close the connection

### DIFF
--- a/http.go
+++ b/http.go
@@ -55,10 +55,6 @@ func (s *HttpServer) Run() error {
 	http.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
-		// We either don't need the body or read it fully below, don't bother
-		// trying to do anything more with it after this func returns.
-		r.Header.Add("Connection", "close")
-
 		if s.Config.EnforceSsl && r.Header.Get("X-Forwarded-Proto") != "https" {
 			http.Error(w, "Only SSL requests accepted", 400)
 			return


### PR DESCRIPTION
This should enable keep alives

Also, go's http library wil auto-consume the rest of the body AFAICT, so
that it can read in the next request.
