### PR TITLE
Inject Logplex-Drain-Token if necessary

### DIFF
--- a/fixer.go
+++ b/fixer.go
@@ -9,7 +9,11 @@ import (
 	"strconv"
 )
 
-func Fix(r io.Reader, remoteAddr string, requestId string) ([]byte, error) {
+const (
+	LOGPLEX_DEFAULT_HOST = "host" // https://github.com/heroku/logplex/blob/master/src/logplex_http_drain.erl#L443
+)
+
+func Fix(r io.Reader, remoteAddr string, requestId string, logplexDrainToken string) ([]byte, error) {
 	nilVal := []byte(`- `)
 
 	var messageWriter bytes.Buffer
@@ -26,7 +30,11 @@ func Fix(r io.Reader, remoteAddr string, requestId string) ([]byte, error) {
 		messageWriter.WriteString(" ")
 		messageWriter.Write(header.Time)
 		messageWriter.WriteString(" ")
-		messageWriter.Write(header.Hostname)
+		if string(header.Hostname) == LOGPLEX_DEFAULT_HOST && logplexDrainToken != "" {
+			messageWriter.WriteString(logplexDrainToken)
+		} else {
+			messageWriter.Write(header.Hostname)
+		}
 		messageWriter.WriteString(" ")
 		messageWriter.Write(header.Name)
 		messageWriter.WriteString(" ")

--- a/fixer_test.go
+++ b/fixer_test.go
@@ -10,31 +10,46 @@ type InputOutput struct {
 	Output []byte
 }
 
+var (
+	input = [][]byte{
+		[]byte("64 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hi\n67 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hello\n"),
+		[]byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("65 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - hello\n"),
+		[]byte("58 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - "),
+	}
+)
+
 func TestFix(t *testing.T) {
-	var inputOutput []InputOutput = []InputOutput{
-		{
-			[]byte("64 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hi\n67 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hello\n"),
-			[]byte("84 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hi\n87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
-		},
-		{
-			[]byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
-			[]byte("127 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
-		},
-		{
-			[]byte("65 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - hello\n"),
-			[]byte("87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
-		},
-		{
-			[]byte("58 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - "),
-			[]byte("80 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"]"),
-		},
+	var output = [][]byte{
+		[]byte("84 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hi\n87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("127 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("80 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"]"),
+	}
+	for x, in := range input {
+		fixed, _ := Fix(bytes.NewReader(in), "1.2.3.4", "request-id", "")
+
+		if !bytes.Equal(fixed, output[x]) {
+			t.Errorf("input=%q\noutput=%q\ngot=%q\n", in, output[x], fixed)
+		}
+	}
+}
+
+func TestFixWithLogplexDrainToken(t *testing.T) {
+	testToken := "d.34bc219c-983b-463e-a17d-3d34ee7db812"
+
+	output := [][]byte{
+		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hi\n121 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("161 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("121 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("114 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"]"),
 	}
 
-	for _, io := range inputOutput {
-		fixed, _ := Fix(bytes.NewReader(io.Input), "1.2.3.4", "request-id")
+	for x, in := range input {
+		fixed, _ := Fix(bytes.NewReader(in), "1.2.3.4", "request-id", testToken)
 
-		if !bytes.Equal(fixed, io.Output) {
-			t.Errorf("input=%q output=%q got=%q\n", io.Input, io.Output, fixed)
+		if !bytes.Equal(fixed, output[x]) {
+			t.Errorf("input=%q\noutput=%q\ngot=%q\n", in, output[x], fixed)
 		}
 	}
 }
@@ -44,7 +59,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Fix(bytes.NewReader(input), "1.2.3.4", "request-id")
+		Fix(bytes.NewReader(input), "1.2.3.4", "request-id", "")
 	}
 }
 
@@ -53,6 +68,6 @@ func BenchmarkFixSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Fix(bytes.NewReader(input), "1.2.3.4", "request-id")
+		Fix(bytes.NewReader(input), "1.2.3.4", "request-id", "")
 	}
 }


### PR DESCRIPTION
Logplex http drains don't pass the drain token in each messages to
"conserve bytes", so we need to inject it when necessary.
