### PR TITLE
Adding support for logging the auth user provided

### DIFF
--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -25,6 +25,7 @@ type IssConfig struct {
 	LibratoSource             string        `env:"LIBRATO_SOURCE"`
 	LibratoOwner              string        `env:"LIBRATO_OWNER"`
 	LibratoToken              string        `env:"LIBRATO_TOKEN"`
+	LogAuthUser               bool          `env:"LOG_AUTH_USER,default=false"`
 	Dyno                      string        `env:"DYNO"`
 	TlsConfig                 *tls.Config
 	MetricsRegistry           metrics.Registry

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -42,10 +42,15 @@ func fix(r io.Reader, remoteAddr, logplexDrainToken, authUser string) ([]byte, e
 		messageWriter.Write(header.Procid)
 		messageWriter.WriteString(" ")
 		messageWriter.Write(header.Msgid)
+
+		if authUser != "" {
+			messageWriter.WriteString(" log_iss_user=")
+			messageWriter.WriteString(authUser)
+		}
+
 		messageWriter.WriteString(" [origin ip=\"")
 		messageWriter.WriteString(remoteAddr)
 		messageWriter.WriteString("\"]")
-
 		b := lp.Bytes()
 		if len(b) >= 2 && bytes.Equal(b[0:2], nilVal) {
 			messageWriter.Write(b[1:])
@@ -54,12 +59,6 @@ func fix(r io.Reader, remoteAddr, logplexDrainToken, authUser string) ([]byte, e
 				messageWriter.WriteString(" ")
 			}
 			messageWriter.Write(b)
-		}
-
-		if authUser != "" {
-			messageWriter.WriteString("log_iss_user=\"")
-			messageWriter.WriteString(authUser)
-			messageWriter.WriteString("\"")
 		}
 
 		messageLenWriter.WriteString(strconv.Itoa(messageWriter.Len()))

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -18,7 +18,7 @@ const (
 var nilVal = []byte(`- `)
 
 // Fix function to convert post data to length prefixed syslog frames
-func fix(r io.Reader, remoteAddr string, logplexDrainToken string) ([]byte, error) {
+func fix(r io.Reader, remoteAddr, logplexDrainToken, authUser string) ([]byte, error) {
 	var messageWriter bytes.Buffer
 	var messageLenWriter bytes.Buffer
 
@@ -54,6 +54,12 @@ func fix(r io.Reader, remoteAddr string, logplexDrainToken string) ([]byte, erro
 				messageWriter.WriteString(" ")
 			}
 			messageWriter.Write(b)
+		}
+
+		if authUser != "" {
+			messageWriter.WriteString("log_iss_user=\"")
+			messageWriter.WriteString(authUser)
+			messageWriter.WriteString("\"")
 		}
 
 		messageLenWriter.WriteString(strconv.Itoa(messageWriter.Len()))

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -39,11 +39,11 @@ func TestFix(t *testing.T) {
 
 func TestFixWithLogAuthUser(t *testing.T) {
 	var output = [][]byte{
-		[]byte("104 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hi\n107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hello\n"),
-		[]byte("147 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
-		[]byte("107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hello\n"),
-		[]byte("100 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"]"),
-		[]byte("138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
+		[]byte("104 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hi log_iss_user=ingest\n107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello log_iss_user=ingest\n"),
+		[]byte("147 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello log_iss_user=ingest\n"),
+		[]byte("107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello log_iss_user=ingest\n"),
+		[]byte("100 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] log_iss_user=ingest"),
+		[]byte("138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527] log_iss_user=ingest"),
 	}
 	for x, in := range input {
 		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", "", "ingest")

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -29,7 +29,7 @@ func TestFix(t *testing.T) {
 		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
-		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", "")
+		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", "", "")
 
 		if !bytes.Equal(fixed, output[x]) {
 			t.Errorf("input=%q\noutput=%q\ngot=%q\n", in, output[x], fixed)
@@ -49,7 +49,7 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 	}
 
 	for x, in := range input {
-		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", testToken)
+		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", testToken, "")
 
 		if !bytes.Equal(fixed, output[x]) {
 			t.Errorf("input=%q\noutput=%q\ngot=%q\n", in, output[x], fixed)
@@ -62,7 +62,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(bytes.NewReader(input), "1.2.3.4", "")
+		fix(bytes.NewReader(input), "1.2.3.4", "", "")
 	}
 }
 
@@ -71,6 +71,6 @@ func BenchmarkFixSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(bytes.NewReader(input), "1.2.3.4", "")
+		fix(bytes.NewReader(input), "1.2.3.4", "", "")
 	}
 }

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -37,6 +37,23 @@ func TestFix(t *testing.T) {
 	}
 }
 
+func TestFixWithLogAuthUser(t *testing.T) {
+	var output = [][]byte{
+		[]byte("104 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hi\n107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("147 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("107 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"] hello\n"),
+		[]byte("100 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"]"),
+		[]byte("138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - log_iss_user=ingest [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
+	}
+	for x, in := range input {
+		fixed, _ := fix(bytes.NewReader(in), "1.2.3.4", "", "ingest")
+
+		if !bytes.Equal(fixed, output[x]) {
+			t.Errorf("input=%q\noutput=%q\ngot=%q\n", in, output[x], fixed)
+		}
+	}
+}
+
 func TestFixWithLogplexDrainToken(t *testing.T) {
 	testToken := "d.34bc219c-983b-463e-a17d-3d34ee7db812"
 
@@ -72,5 +89,23 @@ func BenchmarkFixSD(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fix(bytes.NewReader(input), "1.2.3.4", "", "")
+	}
+}
+
+func BenchmarkLogAuthUserFixNoSD(b *testing.B) {
+	input := []byte("64 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hi\n67 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hello\n")
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fix(bytes.NewReader(input), "1.2.3.4", "", "ingest")
+	}
+}
+
+func BenchmarkLogAuthUserFixSD(b *testing.B) {
+	input := []byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n")
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fix(bytes.NewReader(input), "1.2.3.4", "", "ingest")
 	}
 }

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -153,12 +153,8 @@ func (s *httpServer) Run() error {
 			var ok bool
 			authUser, _, ok = r.BasicAuth()
 
-			if !ok {
-				log.Error("Auth user missing")
-
-				// This shouldn't show up in splunk because the log line should
-				// be rejected without auth.
-				authUser = "none"
+			if !ok || authUser == "" {
+				log.Error("Auth user is missing or invalid")
 			}
 		}
 

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -127,15 +127,9 @@ func (s *httpServer) Run() error {
 			s.pAuthErrors.Inc(1)
 			s.handleHTTPError(w, "Unable to authenticate request", 401)
 			return
-		} else {
-			s.pAuthSuccesses.Inc(1)
 		}
 
-		var authUser string
-
-		if s.Config.LogAuthUser {
-			authUser = r.URL.User.Username()
-		}
+		s.pAuthSuccesses.Inc(1)
 
 		remoteAddr := extractRemoteAddr(r)
 		requestID := r.Header.Get("X-Request-Id")
@@ -151,6 +145,11 @@ func (s *httpServer) Run() error {
 				return
 			}
 			defer body.Close()
+		}
+
+		var authUser string
+		if s.Config.LogAuthUser {
+			authUser = r.URL.User.Username()
 		}
 
 		if err, status := s.process(body, remoteAddr, requestID, logplexDrainToken, authUser); err != nil {


### PR DESCRIPTION
@heroku/sr-tools 

Setting up for rolling logs.herokai.com creds, we're adding the user
used to authenticate to log-iss to each log line. This should help us
determine when it is safe to remove the old cred. I'm putting this
behind a feature flag so we can toggle it off once the cred roll is
complete should we so choose.

Relates to this issue: https://github.com/heroku/srtools/issues/3109

@psutton1179a @kgarigipati I'd be interested in your take on this from the Splunk side... it will effectively add `los_iss_user=ingest` to the end of each in coming log line to Splunk.

@freeformz Adding you for your Go expertise and familiarity with this code base.