### PR TITLE
Logging only procid, hostname and msgid

### DIFF
--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -175,11 +175,17 @@ func (s *httpServer) Run() error {
 			if lp.Next() {
 				h := lp.Header()
 
+				host := string(h.Hostname)
+				if hostname == "host" {
+					hostname = logplexDrainToken
+				}
+
 				log.WithFields(log.Fields{
-					"log_iss_user": authUser,
-					"hostname":     string(h.Hostname),
+					"log_iss_user": hauthUser,
+					"hostname":     hostname,
 					"procid":       string(h.Procid),
-					"msgid":        string(h.Msgid),
+					"request_id":   requestID,
+					"remote_addr":  remoteAddr,
 				}).Info()
 			}
 		}

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bmizerany/lpx"
 	"github.com/heroku/authenticater"
 	metrics "github.com/rcrowley/go-metrics"
 	log "github.com/sirupsen/logrus"
@@ -167,15 +169,15 @@ func (s *httpServer) Run() error {
 		}
 
 		if buf.Len() > 0 {
-			line := make([]byte, 1024)
+			lp := lpx.NewReader(bufio.NewReader(bytes.NewReader(buf.Bytes())))
+			h := lp.Header()
 
-			read, err := buf.Read(line)
-
-			if err != nil {
-				log.Error(err)
-			} else {
-				log.WithFields(log.Fields{"log_iss_user": authUser, "payload": string(line[:read])}).Info()
-			}
+			log.WithFields(log.Fields{
+				"log_iss_user": authUser,
+				"hostname":     h.Hostname,
+				"procid":       h.Procid,
+				"msgid":        h.Msgid,
+			}).Info()
 		}
 
 		s.pSuccesses.Inc(1)

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -175,13 +175,13 @@ func (s *httpServer) Run() error {
 			if lp.Next() {
 				h := lp.Header()
 
-				host := string(h.Hostname)
+				hostname := string(h.Hostname)
 				if hostname == "host" {
 					hostname = logplexDrainToken
 				}
 
 				log.WithFields(log.Fields{
-					"log_iss_user": hauthUser,
+					"log_iss_user": authUser,
 					"hostname":     hostname,
 					"procid":       string(h.Procid),
 					"request_id":   requestID,

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -174,9 +174,9 @@ func (s *httpServer) Run() error {
 
 			log.WithFields(log.Fields{
 				"log_iss_user": authUser,
-				"hostname":     h.Hostname,
-				"procid":       h.Procid,
-				"msgid":        h.Msgid,
+				"hostname":     string(h.Hostname),
+				"procid":       string(h.Procid),
+				"msgid":        string(h.Msgid),
 			}).Info()
 		}
 


### PR DESCRIPTION
Turns out in most cases we just need the procid. Adding a few other
fields incase that doesn't have what we need.

The result of the previous code is really ugly in splunk. This should give us what we need without the duplication of logs. E.g.

```
2018-02-22T01:02:02.072307+00:00 127.0.0.1 local0.err log-iss-web-1[98832]: - ip-192-168-4-210 level=info app=log-iss log_iss_user=ingest payload="1408 <46>1 2018-02-22T01:02:01.778006+00:00 runtime-px.315784@heroku-eu-west-1-a.com /usr/bin/log-shuttle 2113 - [meta sequenceId=\"673\"] batch.fill.count=44 batch.fill.max=0.250000 batch.fill.mean=0.250000 batch.fill.min=0.250000 batch.fill.p75=0.250000 batch.fill.p95=0.250000 batch.fill.p99=0.250000 batch.fill.rate.15min=0.803 batch.fill.rate.1min=0.781 batch.fill.rate.5min=0.805 batch.fill.rate.mean=0.825 batch.fill.stddev=0.000000 lines.batched.count=337 lines.dropped.count=0 lines.read.count=337 log_shuttle_stats_source=d_logdrain_logdrain-urls_0 msg.lost.count=0 outlet.inbox.length=0 outlet.post.failure.count=0 outlet.post.failure.max=0.000000 outlet.post.failure.mean=0.000000 outlet.post.failure.min=0.000000 outlet.post.failure.p75=0.000000 outlet.post.failure.p95=0.000000 outlet.post.failure.p99=0.000000 outlet.post.failure.rate.15min=0.000 outlet.post.failure.rate.1min=0.000 outlet.post.failure.rate.5min=0.000 outlet.post.failure.rate.mean=0.000 o
```


cc @kgarigipati @essobi This should fix the issue you reported.