### PR TITLE
Make metadata id customizable.

### DIFF
--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -28,6 +28,7 @@ type IssConfig struct {
 	Dyno                      string        `env:"DYNO"`
 	ValidTokenUser            string        `env:"VALID_TOKEN_USER"`
 	TokenUserSamplePct        int           `env:"TOKEN_USER_SAMPLE_PCT,default=0"`
+	MetadataId                string        `env:"METADATA_ID"`
 	TlsConfig                 *tls.Config
 	MetricsRegistry           metrics.Registry
 }

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -32,17 +32,17 @@ func TestFix(t *testing.T) {
 		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
-		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "")
+		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "")
 		assert.Equal(string(fixed), string(output[x]))
 	}
 }
 
 func TestFixWithQueryParameters(t *testing.T) {
 	assert := assert.New(t)
-	var output = []byte("131 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata index=\"i\" source=\"s\" sourcetype=\"st\"] hi\n134 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata index=\"i\" source=\"s\" sourcetype=\"st\"] hello\n")
+	var output = []byte("135 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hi\n138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hello\n")
 
 	in := input[0]
-	fixed, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "")
+	fixed, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123")
 
 	assert.Equal(string(fixed), string(output), "They should be equal")
 }
@@ -60,7 +60,7 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 	}
 
 	for x, in := range input {
-		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken)
+		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "")
 
 		assert.Equal(string(fixed), string(output[x]))
 	}
@@ -71,7 +71,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "")
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "")
 	}
 }
 
@@ -80,7 +80,7 @@ func BenchmarkFixSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "")
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "")
 	}
 }
 

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -35,7 +35,7 @@ func NewPayload(sa string, ri string, b []byte) payload {
 	}
 }
 
-type FixerFunc func(*http.Request, io.Reader, string, string) ([]byte, error)
+type FixerFunc func(*http.Request, io.Reader, string, string, string) ([]byte, error)
 
 type httpServer struct {
 	Config         IssConfig
@@ -160,7 +160,7 @@ func (s *httpServer) Run() error {
 			body = ioutil.NopCloser(io.TeeReader(body, &buf))
 		}
 
-		if err, status := s.process(r, body, remoteAddr, requestID, logplexDrainToken); err != nil {
+		if err, status := s.process(r, body, remoteAddr, requestID, logplexDrainToken, s.Config.MetadataId); err != nil {
 			s.handleHTTPError(
 				w, err.Error(), status,
 				log.Fields{"remote_addr": remoteAddr, "requestId": requestID, "logdrain_token": logplexDrainToken},
@@ -202,11 +202,11 @@ func (s *httpServer) awaitShutdown() {
 	log.WithFields(log.Fields{"ns": "http", "at": "shutdown"}).Info()
 }
 
-func (s *httpServer) process(req *http.Request, r io.Reader, remoteAddr string, requestID string, logplexDrainToken string) (error, int) {
+func (s *httpServer) process(req *http.Request, r io.Reader, remoteAddr string, requestID string, logplexDrainToken string, metadataId string) (error, int) {
 	s.Add(1)
 	defer s.Done()
 
-	fixedBody, err := s.FixerFunc(req, r, remoteAddr, logplexDrainToken)
+	fixedBody, err := s.FixerFunc(req, r, remoteAddr, logplexDrainToken, metadataId)
 	if err != nil {
 		return errors.New("Problem fixing body: " + err.Error()), http.StatusBadRequest
 	}


### PR DESCRIPTION
According to RFC 5424 6.3.2 (https://tools.ietf.org/html/rfc5424#section-6.3.2), structured data SD-ID must be in the format `name@<private-enterprise-number>`, unless the structured data is one of the reserved fields. The data we are adding is *not* a reserved field, so we need to make it customizable. 

We'll use something like "metadata@23507" for our value for this (see https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers, look for 23507).