### PR TITLE
Log metrics

### DIFF
--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -19,13 +19,52 @@ const (
 var nilVal = []byte(`- `)
 var queryParams = []string{"index", "source", "sourcetype"}
 
+// Get metadata from the http request.
+// Returns an empty byte array if there isn't any.
+func getMetadata(req *http.Request, metadataId string) (res []byte) {
+	var metadataWriter bytes.Buffer
+	// Calculate metadata query parameters
+	if metadataId != "" {
+		foundMetadata := false
+		for _, k := range queryParams {
+			v := req.FormValue(k)
+			if v != "" {
+				if !foundMetadata {
+					metadataWriter.WriteString("[")
+					metadataWriter.WriteString(metadataId)
+					foundMetadata = true
+				}
+				metadataWriter.WriteString(" ")
+				metadataWriter.WriteString(k)
+				metadataWriter.WriteString("=\"")
+				metadataWriter.WriteString(v)
+				metadataWriter.WriteString("\"")
+			}
+		}
+		if foundMetadata {
+			metadataWriter.WriteString("]")
+		}
+	}
+	return metadataWriter.Bytes()
+}
+
 // Fix function to convert post data to length prefixed syslog frames
-func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken string, metadataId string) ([]byte, error) {
+// Returns:
+// * boolean indicating whether metadata was present in the query parameters.
+// * integer representing the number of logplex frames parsed from the HTTP request.
+// * byte array of syslog data.
+// * error if something went wrong.
+func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken string, metadataId string) (bool, int64, []byte, error) {
 	var messageWriter bytes.Buffer
 	var messageLenWriter bytes.Buffer
 
+	metadataBytes := getMetadata(req, metadataId)
+	hasMetadata := len(metadataBytes) > 0
+
 	lp := lpx.NewReader(bufio.NewReader(r))
+	numLogs := int64(0)
 	for lp.Next() {
+		numLogs++
 		header := lp.Header()
 
 		// LEN SP PRI VERSION SP TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID SP STRUCTURED-DATA MSG
@@ -48,27 +87,9 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		messageWriter.WriteString(remoteAddr)
 		messageWriter.WriteString("\"]")
 
-		// Add metadata from query parameters
-		if metadataId != "" {
-			foundMetadata := false
-			for _, k := range queryParams {
-				v := req.FormValue(k)
-				if v != "" {
-					if !foundMetadata {
-						messageWriter.WriteString("[")
-						messageWriter.WriteString(metadataId)
-						foundMetadata = true
-					}
-					messageWriter.WriteString(" ")
-					messageWriter.WriteString(k)
-					messageWriter.WriteString("=\"")
-					messageWriter.WriteString(v)
-					messageWriter.WriteString("\"")
-				}
-			}
-			if foundMetadata {
-				messageWriter.WriteString("]")
-			}
+		// Write metadata
+		if hasMetadata {
+			messageWriter.Write(metadataBytes)
 		}
 
 		b := lp.Bytes()
@@ -86,5 +107,5 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		messageWriter.WriteTo(&messageLenWriter)
 	}
 
-	return messageLenWriter.Bytes(), lp.Err()
+	return hasMetadata, numLogs, messageLenWriter.Bytes(), lp.Err()
 }

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -21,11 +21,11 @@ var queryParams = []string{"index", "source", "sourcetype"}
 
 // Get metadata from the http request.
 // Returns an empty byte array if there isn't any.
-func getMetadata(req *http.Request, metadataId string) (res []byte) {
+func getMetadata(req *http.Request, metadataId string) ([]byte, bool) {
 	var metadataWriter bytes.Buffer
+	var foundMetadata bool
 	// Calculate metadata query parameters
 	if metadataId != "" {
-		foundMetadata := false
 		for _, k := range queryParams {
 			v := req.FormValue(k)
 			if v != "" {
@@ -45,7 +45,7 @@ func getMetadata(req *http.Request, metadataId string) (res []byte) {
 			metadataWriter.WriteString("]")
 		}
 	}
-	return metadataWriter.Bytes()
+	return metadataWriter.Bytes(), foundMetadata
 }
 
 // Fix function to convert post data to length prefixed syslog frames
@@ -58,8 +58,7 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 	var messageWriter bytes.Buffer
 	var messageLenWriter bytes.Buffer
 
-	metadataBytes := getMetadata(req, metadataId)
-	hasMetadata := len(metadataBytes) > 0
+	metadataBytes, hasMetadata := getMetadata(req, metadataId)
 
 	lp := lpx.NewReader(bufio.NewReader(r))
 	numLogs := int64(0)

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -32,8 +32,9 @@ func TestFix(t *testing.T) {
 		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
-		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "")
+		hasMetadata, _, fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "")
 		assert.Equal(string(fixed), string(output[x]))
+		assert.False(hasMetadata)
 	}
 }
 
@@ -42,9 +43,11 @@ func TestFixWithQueryParameters(t *testing.T) {
 	var output = []byte("135 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hi\n138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hello\n")
 
 	in := input[0]
-	fixed, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123")
+	hasMetadata, numLogs, fixed, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123")
 
 	assert.Equal(string(fixed), string(output), "They should be equal")
+	assert.True(hasMetadata)
+	assert.Equal(int64(2), numLogs)
 }
 
 func TestFixWithLogplexDrainToken(t *testing.T) {
@@ -60,9 +63,9 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 	}
 
 	for x, in := range input {
-		fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "")
-
+		hasMetadata, _, fixed, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "")
 		assert.Equal(string(fixed), string(output[x]))
+		assert.False(hasMetadata)
 	}
 }
 

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -227,8 +227,8 @@ func (s *httpServer) process(req *http.Request, r io.Reader, remoteAddr string, 
 	payload := NewPayload(remoteAddr, requestID, fixedBody)
 	if err := s.deliverer.Deliver(payload); err != nil {
 		return errors.New("Problem delivering body: " + err.Error()), http.StatusGatewayTimeout
-	} else {
 	}
+
 	s.pLogsSent.Inc(numLogs)
 	if hasMetadata {
 		s.pMetadataLogsSent.Inc(numLogs)


### PR DESCRIPTION
Add metrics for:
* number of incoming logs (from http)
* number of outgoing logs (to syslog)
* number of incoming logs that have metadata (from http)
* number of outgoing logs that have metadata (from http)

Also refactor metadata detection so that we only run it once per http request, instead of repeating it for every log in an http request.