### PR TITLE
replace token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO_LINKER_SYMBOL := "main.version"
+GO_LINKER_VALUE := $(shell git describe --tags --always | sed s/^v//)
 
 all: test
 
@@ -9,11 +10,9 @@ bench:
 	govendor test -v -bench=. +local
 
 install:
-	$(eval GO_LINKER_VALUE := $(shell git describe --tags --always | sed s/^v//))
 	go install -a -ldflags "-X ${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}" ./...
 
 build:
-	$(eval GO_LINKER_VALUE := $(shell git describe --tags --always | sed s/^v//))
 	go build -a -ldflags "-X ${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}" ./...
 
 update-deps: govendor

--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -30,6 +30,7 @@ type IssConfig struct {
 	Debug                     bool          `env:"LOG_ISS_DEBUG"`
 	TlsConfig                 *tls.Config
 	MetricsRegistry           metrics.Registry
+	tokenMap                  map[string]string
 }
 
 func NewIssConfig() (IssConfig, error) {
@@ -66,4 +67,18 @@ func NewIssConfig() (IssConfig, error) {
 	config.MetricsRegistry = metrics.NewRegistry()
 
 	return config, nil
+}
+
+func (c *IssConfig) TokenMap() map[string]string {
+	if c.tokenMap == nil {
+		pairs := strings.Split(c.Tokens, "|")
+		c.tokenMap = make(map[string]string)
+
+		for _, pair := range pairs {
+			unameToken := strings.Split(pair, ":")
+			c.tokenMap[unameToken[0]] = unameToken[1]
+		}
+	}
+
+	return c.tokenMap
 }

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -215,7 +215,7 @@ func (s *httpServer) process(req *http.Request, r io.Reader, remoteAddr string, 
 	for user, token := range s.Config.TokenMap() {
 		t := []byte(token)
 		if bytes.Contains(fixedBody, t) {
-			fixedBody = bytes.Replace(fixedBody, t, []byte(user), -1)
+			fixedBody = bytes.Replace(fixedBody, t, []byte("token:"+user), -1)
 		}
 	}
 

--- a/vendor/github.com/joeshaw/envdecode/README.md
+++ b/vendor/github.com/joeshaw/envdecode/README.md
@@ -1,4 +1,4 @@
-# envdecode #
+# envdecode [![Travis-CI](https://travis-ci.org/joeshaw/envdecode.svg)](https://travis-ci.org/joeshaw/envdecode) [![GoDoc](https://godoc.org/github.com/joeshaw/envdecode?status.svg)](https://godoc.org/github.com/joeshaw/envdecode)
 
 `envdecode` is a Go package for populating structs from environment
 variables.
@@ -8,10 +8,10 @@ allowing you you use any names you want for environment variables.
 `envdecode` will recurse into nested structs, including pointers to
 nested structs, but it will not allocate new pointers to structs.
 
-## API ##
+## API
 
 Full API docs are available on
-[godoc.org](http://godoc.org/github.com/joeshaw/envdecode).
+[godoc.org](https://godoc.org/github.com/joeshaw/envdecode).
 
 Define a struct with `env` struct tags:
 
@@ -21,11 +21,12 @@ type Config struct {
     Port      uint16 `env:"SERVER_PORT,default=8080"`
 
     AWS struct {
-        ID     string `env:"AWS_ACCESS_KEY_ID"`
-        Secret string `env:"AWS_SECRET_ACCESS_KEY,required"`
+        ID        string   `env:"AWS_ACCESS_KEY_ID"`
+        Secret    string   `env:"AWS_SECRET_ACCESS_KEY,required"`
+        SnsTopics []string `env:"AWS_SNS_TOPICS"`
     }
 
-    Timeout time.Duration `env:"TIMEOUT,default=1m"`
+    Timeout time.Duration `env:"TIMEOUT,default=1m,strict"`
 }
 ```
 
@@ -33,6 +34,10 @@ Fields *must be exported* (i.e. begin with a capital letter) in order
 for `envdecode` to work with them.  An error will be returned if a
 struct with no exported fields is decoded (including one that contains
 no `env` tags at all).
+Default values may be provided by appending ",default=value" to the
+struct tag. Required values may be marked by appending ",required" to the
+struct tag. Strict values may be marked by appending ",strict" which will
+return an error on Decode if there is an error while parsing.
 
 Then call `envdecode.Decode`:
 
@@ -41,9 +46,19 @@ var cfg Config
 err := envdecode.Decode(&cfg)
 ```
 
-## Supported types ##
+If you want all fields to act `strict`, you may use `envdecode.StrictDecode`:
+
+```go
+var cfg Config
+err := envdecode.StrictDecode(&cfg)
+```
+
+All parse errors will fail fast and return an error in this mode.
+
+## Supported types
 
 * Structs (and pointer to structs)
+* Slices of below defined types, separated by semicolon
 * `bool`
 * `float32`, `float64`
 * `int`, `int8`, `int16`, `int32`, `int64`
@@ -51,3 +66,24 @@ err := envdecode.Decode(&cfg)
 * `string`
 * `time.Duration`, using the [`time.ParseDuration()` format](http://golang.org/pkg/time/#ParseDuration)
 * `*url.URL`, using [`url.Parse()`](https://godoc.org/net/url#Parse)
+* Types those implement a `Decoder` interface
+
+## Custom `Decoder`
+
+If you want a field to be decoded with custom behavior, you may implement the interface `Decoder` for the filed type.
+
+```go
+type Config struct {
+  IPAddr IP `env:"IP_ADDR"`
+}
+
+type IP net.IP
+
+// Decode implements the interface `envdecode.Decoder`
+func (i *IP) Decode(repl string) error {
+  *i = net.ParseIP(repl)
+  return nil
+}
+```
+
+`Decoder` is the interface implemented by an object that can decode an environment variable string representation of itself.

--- a/vendor/github.com/joeshaw/envdecode/envdecode.go
+++ b/vendor/github.com/joeshaw/envdecode/envdecode.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 // ErrInvalidTarget indicates that the target value passed to
 // Decode is invalid.  Target must be a non-nil pointer to a struct.
 var ErrInvalidTarget = errors.New("target must be non-nil pointer to struct that has at least one exported field with a valid env tag.")
+var ErrNoTargetFieldsAreSet = errors.New("none of the target fields were set from environment variables")
 
 // FailureFunc is called when an error is encountered during a MustDecode
 // operation. It prints the error and terminates the process.
@@ -28,6 +30,12 @@ var FailureFunc = func(err error) {
 	log.Fatalf("envdecode: an error was encountered while decoding: %v\n", err)
 }
 
+// Decoder is the interface implemented by an object that can decode an
+// environment variable string representation of itself.
+type Decoder interface {
+	Decode(string) error
+}
+
 // Decode environment variables into the provided target.  The target
 // must be a non-nil pointer to a struct.  Fields in the struct must
 // be exported, and tagged with an "env" struct tag with a value
@@ -37,7 +45,9 @@ var FailureFunc = func(err error) {
 // Default values may be provided by appending ",default=value" to the
 // struct tag.  Required values may be marked by appending ",required"
 // to the struct tag.  It is an error to provide both "default" and
-// "required".
+// "required". Strict values may be marked by appending ",strict" which
+// will return an error on Decode if there is an error while parsing.
+// If everything must be strict, consider using StrictDecode instead.
 //
 // All primitive types are supported, including bool, floating point,
 // signed and unsigned integers, and string.  Boolean and numeric
@@ -45,21 +55,57 @@ var FailureFunc = func(err error) {
 // those types.  Structs and pointers to structs are decoded
 // recursively.  time.Duration is supported via the
 // time.ParseDuration() function and *url.URL is supported via the
-// url.Parse() function.
+// url.Parse() function. Slices are supported for all above mentioned
+// primitive types. Semicolon is used as delimiter in environment variables.
 func Decode(target interface{}) error {
+	nFields, err := decode(target, false)
+	if err != nil {
+		return err
+	}
+
+	// if we didn't do anything - the user probably did something
+	// wrong like leave all fields unexported.
+	if nFields == 0 {
+		return ErrNoTargetFieldsAreSet
+	}
+
+	return nil
+}
+
+// StrictDecode is similar to Decode except all fields will have an implicit
+// ",strict" on all fields.
+func StrictDecode(target interface{}) error {
+	nFields, err := decode(target, true)
+	if err != nil {
+		return err
+	}
+
+	// if we didn't do anything - the user probably did something
+	// wrong like leave all fields unexported.
+	if nFields == 0 {
+		return ErrInvalidTarget
+	}
+
+	return nil
+}
+
+func decode(target interface{}, strict bool) (int, error) {
 	s := reflect.ValueOf(target)
 	if s.Kind() != reflect.Ptr || s.IsNil() {
-		return ErrInvalidTarget
+		return 0, ErrInvalidTarget
 	}
 
 	s = s.Elem()
 	if s.Kind() != reflect.Struct {
-		return ErrInvalidTarget
+		return 0, ErrInvalidTarget
 	}
 
 	t := s.Type()
 	setFieldCount := 0
 	for i := 0; i < s.NumField(); i++ {
+		// Localize the umbrella `strict` value to the specific field.
+		strict := strict
+
 		f := s.Field(i)
 
 		switch f.Kind() {
@@ -72,8 +118,21 @@ func Decode(target interface{}) error {
 			fallthrough
 
 		case reflect.Struct:
+			if !f.Addr().CanInterface() {
+				continue
+			}
+
 			ss := f.Addr().Interface()
-			Decode(ss)
+			_, custom := ss.(Decoder)
+			if custom {
+				break
+			}
+
+			n, err := decode(ss, strict)
+			if err != nil {
+				return 0, err
+			}
+			setFieldCount += n
 		}
 
 		if !f.CanSet() {
@@ -100,77 +159,117 @@ func Decode(target interface{}) error {
 				hasDefault = true
 				defaultValue = o[8:]
 			}
+			if !strict {
+				strict = strings.HasPrefix(o, "strict")
+			}
 		}
 
 		if required && hasDefault {
 			panic(`envdecode: "default" and "required" may not be specified in the same annotation`)
 		}
 		if env == "" && required {
-			return fmt.Errorf("the environment variable \"%s\" is missing", parts[0])
+			return 0, fmt.Errorf("the environment variable \"%s\" is missing", parts[0])
 		}
 		if env == "" {
 			env = defaultValue
 		}
-
 		if env == "" {
 			continue
 		}
 
 		setFieldCount++
 
-		switch f.Kind() {
-		case reflect.Bool:
-			v, err := strconv.ParseBool(env)
-			if err == nil {
-				f.SetBool(v)
+		decoder, custom := f.Addr().Interface().(Decoder)
+		if custom {
+			if err := decoder.Decode(env); err != nil {
+				return 0, err
 			}
-
-		case reflect.Float32, reflect.Float64:
-			bits := f.Type().Bits()
-			v, err := strconv.ParseFloat(env, bits)
-			if err == nil {
-				f.SetFloat(v)
-			}
-
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
-				v, err := time.ParseDuration(env)
-				if err == nil {
-					f.SetInt(int64(v))
-				}
-			} else {
-				bits := f.Type().Bits()
-				v, err := strconv.ParseInt(env, 0, bits)
-				if err == nil {
-					f.SetInt(v)
-				}
-			}
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			bits := f.Type().Bits()
-			v, err := strconv.ParseUint(env, 0, bits)
-			if err == nil {
-				f.SetUint(v)
-			}
-
-		case reflect.String:
-			f.SetString(env)
-
-		case reflect.Ptr:
-			if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
-				v, err := url.Parse(env)
-				if err == nil {
-					f.Set(reflect.ValueOf(v))
-				}
+		} else if f.Kind() == reflect.Slice {
+			decodeSlice(&f, env)
+		} else {
+			if err := decodePrimitiveType(&f, env); err != nil && strict {
+				return 0, err
 			}
 		}
 	}
 
-	// if we didn't do anything - the user probably did something
-	// wrong like leave all fields unexported.
-	if setFieldCount == 0 {
-		return ErrInvalidTarget
+	return setFieldCount, nil
+}
+
+func decodeSlice(f *reflect.Value, env string) {
+	parts := strings.Split(env, ";")
+
+	values := parts[:0]
+	for _, x := range parts {
+		if x != "" {
+			values = append(values, strings.TrimSpace(x))
+		}
 	}
 
+	valuesCount := len(values)
+	slice := reflect.MakeSlice(f.Type(), valuesCount, valuesCount)
+	if valuesCount > 0 {
+		for i := 0; i < valuesCount; i++ {
+			e := slice.Index(i)
+			decodePrimitiveType(&e, values[i])
+		}
+	}
+
+	f.Set(slice)
+}
+
+func decodePrimitiveType(f *reflect.Value, env string) error {
+	switch f.Kind() {
+	case reflect.Bool:
+		v, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		f.SetBool(v)
+
+	case reflect.Float32, reflect.Float64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseFloat(env, bits)
+		if err != nil {
+			return err
+		}
+		f.SetFloat(v)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
+			v, err := time.ParseDuration(env)
+			if err != nil {
+				return err
+			}
+			f.SetInt(int64(v))
+		} else {
+			bits := f.Type().Bits()
+			v, err := strconv.ParseInt(env, 0, bits)
+			if err != nil {
+				return err
+			}
+			f.SetInt(v)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseUint(env, 0, bits)
+		if err != nil {
+			return err
+		}
+		f.SetUint(v)
+
+	case reflect.String:
+		f.SetString(env)
+
+	case reflect.Ptr:
+		if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
+			v, err := url.Parse(env)
+			if err != nil {
+				return err
+			}
+			f.Set(reflect.ValueOf(v))
+		}
+	}
 	return nil
 }
 
@@ -181,4 +280,138 @@ func MustDecode(target interface{}) {
 	if err != nil {
 		FailureFunc(err)
 	}
+}
+
+// MustStrictDecode calls StrictDecode and terminates the process if any errors
+// are encountered.
+func MustStrictDecode(target interface{}) {
+	err := StrictDecode(target)
+	if err != nil {
+		FailureFunc(err)
+	}
+}
+
+//// Configuration info for Export
+
+type ConfigInfo struct {
+	Field        string
+	EnvVar       string
+	Value        string
+	DefaultValue string
+	HasDefault   bool
+	Required     bool
+	UsesEnv      bool
+}
+
+type ConfigInfoSlice []*ConfigInfo
+
+func (c ConfigInfoSlice) Less(i, j int) bool {
+	return c[i].EnvVar < c[j].EnvVar
+}
+func (c ConfigInfoSlice) Len() int {
+	return len(c)
+}
+func (c ConfigInfoSlice) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// Returns a list of final configuration metadata sorted by envvar name
+func Export(target interface{}) ([]*ConfigInfo, error) {
+	s := reflect.ValueOf(target)
+	if s.Kind() != reflect.Ptr || s.IsNil() {
+		return nil, ErrInvalidTarget
+	}
+
+	cfg := []*ConfigInfo{}
+
+	s = s.Elem()
+	if s.Kind() != reflect.Struct {
+		return nil, ErrInvalidTarget
+	}
+
+	t := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		fName := t.Field(i).Name
+
+		fElem := f
+		if f.Kind() == reflect.Ptr {
+			fElem = f.Elem()
+		}
+		if fElem.Kind() == reflect.Struct {
+			ss := fElem.Addr().Interface()
+			subCfg, err := Export(ss)
+			if err != ErrInvalidTarget {
+				f = fElem
+				for _, v := range subCfg {
+					v.Field = fmt.Sprintf("%s.%s", fName, v.Field)
+					cfg = append(cfg, v)
+				}
+			}
+		}
+
+		tag := t.Field(i).Tag.Get("env")
+		if tag == "" {
+			continue
+		}
+
+		parts := strings.Split(tag, ",")
+
+		ci := &ConfigInfo{
+			Field:   fName,
+			EnvVar:  parts[0],
+			UsesEnv: os.Getenv(parts[0]) != "",
+		}
+
+		for _, o := range parts[1:] {
+			if strings.HasPrefix(o, "default=") {
+				ci.HasDefault = true
+				ci.DefaultValue = o[8:]
+			} else if strings.HasPrefix(o, "required") {
+				ci.Required = true
+			}
+		}
+
+		if f.Kind() == reflect.Ptr && f.IsNil() {
+			ci.Value = ""
+		} else if stringer, ok := f.Interface().(fmt.Stringer); ok {
+			ci.Value = stringer.String()
+		} else {
+			switch f.Kind() {
+			case reflect.Bool:
+				ci.Value = strconv.FormatBool(f.Bool())
+
+			case reflect.Float32, reflect.Float64:
+				bits := f.Type().Bits()
+				ci.Value = strconv.FormatFloat(f.Float(), 'f', -1, bits)
+
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				ci.Value = strconv.FormatInt(f.Int(), 10)
+
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				ci.Value = strconv.FormatUint(f.Uint(), 10)
+
+			case reflect.String:
+				ci.Value = f.String()
+
+			case reflect.Slice:
+				ci.Value = fmt.Sprintf("%v", f.Interface())
+
+			default:
+				// Unable to determine string format for value
+				return nil, ErrInvalidTarget
+			}
+		}
+
+		cfg = append(cfg, ci)
+	}
+
+	// No configuration tags found, assume invalid input
+	if len(cfg) == 0 {
+		return nil, ErrInvalidTarget
+	}
+
+	sort.Sort(ConfigInfoSlice(cfg))
+
+	return cfg, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-08-18T21:26:24Z"
 		},
 		{
-			"checksumSHA1": "FRW8ysy5QhVAFnSbbV8+7boiQzM=",
+			"checksumSHA1": "d8KsRg6DhXtmC8rg9RCOux5Gi60=",
 			"path": "github.com/joeshaw/envdecode",
-			"revision": "8f3fa5fb853793067e184bdc4fe8ac0b3320a9a2",
-			"revisionTime": "2015-01-12T15:57:38Z"
+			"revision": "c9e0158544672841c3ebf49308f536d918f2e525",
+			"revisionTime": "2018-03-03T00:14:13Z"
 		},
 		{
 			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",


### PR DESCRIPTION
I need to do more testing on this, but this should replace any instance of the token used for accessing log-iss with the username used.

---
@Myrcurial (cc @CobyR @tcrayford)

Jamie,

This is a follow up to our discussion with Tom last week. This should scrub out tokens in both Splunk and Nemesis, while still allowing for some tracing via the username used.