### PR TITLE
Make redis and tokens both optional.

### DIFF
--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -32,10 +32,10 @@ type IssConfig struct {
 }
 
 type AuthConfig struct {
-	RedisUrl        string        `env:"REDIS_URL,required"`
-	RedisKey        string        `env:"REDIS_KEY",required`
+	RedisUrl        string        `env:"REDIS_URL`
+	RedisKey        string        `env:"REDIS_KEY"`
 	RefreshInterval time.Duration `env:"CREDENTIAL_REFRESH_INTERVAL,default=1m,strict"`
-	Tokens          string        `env:"TOKEN_MAP,required"`
+	Tokens          string        `env:"TOKEN_MAP"`
 }
 
 func NewAuthConfig() (AuthConfig, error) {


### PR DESCRIPTION
We want to allow configuration for both tokens and redis to be optional - but we want to require at least one of them to be set. With this in place, you can choose to set:

1. REDIS_URL and REDIS_KEY
2. TOKEN_MAP
3. Both of the above.

If neither of these is set, log-iss will fail to start.