### PR TITLE
Optimize Fixer

### DIFF
--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -101,6 +101,15 @@ func BenchmarkFixSD(b *testing.B) {
 	}
 }
 
+func BenchmarkFixSDWithMetadata(b *testing.B) {
+	input := []byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n")
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "meta", nil)
+	}
+}
+
 func httpRequestWithParams() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st", nil)
 	return req

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -53,7 +53,7 @@ func TestFixWithQueryParameters(t *testing.T) {
 
 func TestFixWithDeprecatedCredential(t *testing.T) {
 	assert := assert.New(t)
-	var output = []byte("203 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"{'credential_deprecated': true, 'credential_name': 'cred'}\"] hi\n206 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"{'credential_deprecated': true, 'credential_name': 'cred'}\"] hello\n")
+	var output = []byte("192 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"credential_deprecated=true,credential_name=cred\"] hi\n195 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"credential_deprecated=true,credential_name=cred\"] hello\n")
 
 	in := input[0]
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}


### PR DESCRIPTION
This uses a sync.Pool to keep a series of already initialized
bytes.Buffers and removed some un-needed checks.

Here are the changes courtesy of benchcmp:

|benchmark|old ns/op|new ns/op|delta|
|--|--|--|--|
|BenchmarkFixNoSD-8|3516|3161|-10.10%|
|BenchmarkFixSD-8|2472|2277|-7.89%|
|BenchmarkFixSDWithMetadata-8|2695|2525|-6.31%|

|benchmark|old MB/s|new MB/s|speedup|
|--|--|--|--|
|BenchmarkFixNoSD-8|38.95|43.33|1.11x|
|BenchmarkFixSD-8|44.49|48.29|1.09x|
|BenchmarkFixSDWithMetadata-8|40.82|43.56|1.07x|

|benchmark|old allocs|new allocs|delta|
|--|--|--|--|
|BenchmarkFixNoSD-8|44|39|-11.36%|
|BenchmarkFixSD-8|29|24|-17.24%|
|BenchmarkFixSDWithMetadata-8|32|27|-15.62%|

|benchmark|old bytes|new bytes|delta|
|--|--|--|--|
|BenchmarkFixNoSD-8|5992|5449|-9.06%|
|BenchmarkFixSD-8|5760|5185|-9.98%|
|BenchmarkFixSDWithMetadata-8|5872|5298|-9.78%|