### PR TITLE
Prevent accidental commit of .env files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /forwarder
+.env*


### PR DESCRIPTION
### Context

I use `godotenv` for testing locally, as many do. Often creds are added to `.env` in a the local workspace. I'm adding that file to the ignores list to ensure that creds aren't accidentally committed.