### PR TITLE
Allow for custom query parameters

### DIFF
--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -27,6 +27,7 @@ type IssConfig struct {
 	Dyno                      string        `env:"DYNO"`
 	MetadataId                string        `env:"METADATA_ID"`
 	Debug                     bool          `env:"LOG_ISS_DEBUG"`
+	QueryFieldParams          []string      `env:"LOG_ISS_FIELD_PARAMS"`
 	TlsConfig                 *tls.Config
 	MetricsRegistry           metrics.Registry
 }

--- a/cmd/forwarder/config_test.go
+++ b/cmd/forwarder/config_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryFieldParams(t *testing.T) {
+	assert := assert.New(t)
+
+	setupDefaultEnv()
+	os.Setenv("LOG_ISS_FIELD_PARAMS", "custom1;custom2;custom3")
+
+	config, err := NewIssConfig()
+	if err != nil {
+		assert.FailNow(err.Error())
+	}
+
+	assert.IsType(make([]string, 0), config.QueryFieldParams)
+	assert.ElementsMatch([]string{"custom1", "custom2", "custom3"}, config.QueryFieldParams)
+}
+
+func setupDefaultEnv() {
+	os.Setenv("DEPLOY", "codetest")
+	os.Setenv("FORWARD_DEST", "127.0.0.1:5001")
+	os.Setenv("PORT", "8080")
+}

--- a/cmd/forwarder/config_test.go
+++ b/cmd/forwarder/config_test.go
@@ -18,7 +18,6 @@ func TestQueryFieldParams(t *testing.T) {
 		assert.FailNow(err.Error())
 	}
 
-	assert.IsType(make([]string, 0), config.QueryFieldParams)
 	assert.ElementsMatch([]string{"custom1", "custom2", "custom3"}, config.QueryFieldParams)
 }
 

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -31,7 +31,7 @@ func TestFix(t *testing.T) {
 	}
 
 	for x, in := range input {
-		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "", nil)
+		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "", nil, make([]string, 0))
 		assert.Equal(string(output[x]), string(r.bytes))
 		assert.False(r.hasMetadata)
 	}
@@ -86,7 +86,7 @@ func TestTruncationOfFields(t *testing.T) {
 
 	for _, i := range tests {
 		t.Run(i.name, func(t *testing.T) {
-			r, err := fix(simpleHttpRequest(), bytes.NewReader(i.bytes), "", "", "", nil)
+			r, err := fix(simpleHttpRequest(), bytes.NewReader(i.bytes), "", "", "", nil, make([]string, 0))
 			assert.Equal(i.err, err)
 			assert.Equal(i.expected, r)
 		})
@@ -98,11 +98,40 @@ func TestFixWithQueryParameters(t *testing.T) {
 	var output = []byte("135 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hi\n138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hello\n")
 
 	in := input[0]
-	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil)
+	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, make([]string, 0))
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
 	assert.Equal(int64(2), r.numLogs)
+}
+
+func TestFixWithCustomQueryParameters(t *testing.T) {
+	assert := assert.New(t)
+	var output = []byte("216 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2,credential_deprecated=true,credential_name=cred\"] hi\n219 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2,credential_deprecated=true,credential_name=cred\"] hello\n")
+
+	customQueryParams := []string{"custom1", "custom2"}
+
+	in := input[0]
+	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
+	r, _ := fix(httpRequestWithCustomParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, customQueryParams)
+
+	assert.Equal(string(output), string(r.bytes))
+	assert.True(r.hasMetadata)
+	assert.Equal(r.numLogs, int64(2))
+}
+
+func TestFixWithCustomQueryParametersNoCreds(t *testing.T) {
+	assert := assert.New(t)
+	var output = []byte("168 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2\"] hi\n171 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2\"] hello\n")
+
+	customQueryParams := []string{"custom1", "custom2"}
+
+	in := input[0]
+	r, _ := fix(httpRequestWithCustomParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, customQueryParams)
+
+	assert.Equal(string(output), string(r.bytes))
+	assert.True(r.hasMetadata)
+	assert.Equal(r.numLogs, int64(2))
 }
 
 func TestFixWithDeprecatedCredential(t *testing.T) {
@@ -111,7 +140,7 @@ func TestFixWithDeprecatedCredential(t *testing.T) {
 
 	in := input[0]
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
-	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred)
+	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, make([]string, 0))
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
@@ -130,9 +159,21 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 		[]byte("152 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
-		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "", nil)
+		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "", nil, make([]string, 0))
 		assert.Equal(string(output[x]), string(r.bytes))
 		assert.False(r.hasMetadata)
+	}
+}
+
+func BenchmarkGetMetadata(b *testing.B) {
+	input := []byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n")
+	customQueryParams := []string{"custom1", "custom2"}
+	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
+
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fix(httpRequestWithCustomParams(), bytes.NewReader(input), "1.2.3.4", "", "metadata@123", &cred, customQueryParams)
 	}
 }
 
@@ -141,7 +182,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil)
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))
 	}
 }
 
@@ -150,12 +191,17 @@ func BenchmarkFixSD(b *testing.B) {
 	b.SetBytes(int64(len(input)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil)
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))
 	}
 }
 
 func httpRequestWithParams() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st", nil)
+	return req
+}
+
+func httpRequestWithCustomParams() *http.Request {
+	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&custom1=cq1&custom2=cq2", nil)
 	return req
 }
 

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -171,6 +171,7 @@ func BenchmarkGetMetadata(b *testing.B) {
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
 
 	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fix(httpRequestWithCustomParams(), bytes.NewReader(input), "1.2.3.4", "", "metadata@123", &cred, customQueryParams)
@@ -180,6 +181,7 @@ func BenchmarkGetMetadata(b *testing.B) {
 func BenchmarkFixNoSD(b *testing.B) {
 	input := []byte("64 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hi\n67 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hello\n")
 	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))
@@ -189,6 +191,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 func BenchmarkFixSD(b *testing.B) {
 	input := []byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n")
 	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))

--- a/cmd/forwarder/helpers.go
+++ b/cmd/forwarder/helpers.go
@@ -1,0 +1,11 @@
+package main
+
+// Searches a slice for a string
+func containsString(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -37,11 +37,12 @@ func NewPayload(sa string, ri string, b []byte) payload {
 //  * string - logplex drain token
 //  * metadataId - ID to use when adding metadata to logs
 //  * credential - the credential used to authenticate
+//  * []string - a slice of custom query paramters to look for in the request
 // FixerFunc returns:
-//	* boolean - indicating whether the request has query params (aka metadata).
+//  * boolean - indicating whether the request has query params (aka metadata).
 //  * int64  - number of log lines read from the stream
 //  * error - if something went wrong.
-type FixerFunc func(*http.Request, io.Reader, string, string, string, *credential) (fixResult, error)
+type FixerFunc func(*http.Request, io.Reader, string, string, string, *credential, []string) (fixResult, error)
 
 type httpServer struct {
 	Config                IssConfig
@@ -219,7 +220,7 @@ func (s *httpServer) process(req *http.Request, reader io.Reader, remoteAddr str
 	s.Add(1)
 	defer s.Done()
 
-	r, err := s.FixerFunc(req, reader, remoteAddr, logplexDrainToken, metadataId, cred)
+	r, err := s.FixerFunc(req, reader, remoteAddr, logplexDrainToken, metadataId, cred, s.Config.QueryFieldParams)
 	if err != nil {
 		return errors.New("Problem fixing body: " + err.Error()), http.StatusBadRequest
 	}


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
Heroku needs the ability to send custom query parameters.  When custom query parameters are present, these parameters are passed along as part of the fields metadata.  
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
Take a comma delimited list of custom query paramter keys from an environment variable (`LOG_ISS_FIELD_PARAMS`) and process them as indicated above.
<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
- [x] Create tests and make sure they pass
- [x] Deploy to staging and test
- [ ]  Deploy to production
<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference

<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
