### PR TITLE
Add metrics destination metadata support

### DIFF
--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -23,7 +23,7 @@ const (
 )
 
 var nilVal = []byte("- ")
-var queryParams = []string{"index", "source", "sourcetype"}
+var queryParams = []string{"index", "source", "sourcetype", "metrics-destination"}
 
 // Get metadata from the http request.
 // Returns an empty byte array if there isn't any.

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -134,6 +134,19 @@ func TestFixWithCustomQueryParametersNoCreds(t *testing.T) {
 	assert.Equal(r.numLogs, int64(2))
 }
 
+func TestFixWithMetricsDestination(t *testing.T) {
+	assert := assert.New(t)
+	var output = []byte("171 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" metrics-destination=\"argus,librato\"] hi\n174 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" metrics-destination=\"argus,librato\"] hello\n")
+
+	in := input[0]
+	r, _ := fix(httpRequestWithMetricsDestination(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, nil)
+
+	assert.Equal(string(output), string(r.bytes))
+	assert.True(r.hasMetadata)
+	assert.Equal(r.numLogs, int64(2))
+
+}
+
 func TestFixWithDeprecatedCredential(t *testing.T) {
 	assert := assert.New(t)
 	var output = []byte("192 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"credential_deprecated=true,credential_name=cred\"] hi\n195 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"credential_deprecated=true,credential_name=cred\"] hello\n")
@@ -205,6 +218,11 @@ func httpRequestWithParams() *http.Request {
 
 func httpRequestWithCustomParams() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&custom1=cq1&custom2=cq2", nil)
+	return req
+}
+
+func httpRequestWithMetricsDestination() *http.Request {
+	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&metrics-destination=argus,librato", nil)
 	return req
 }
 


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
Modify log-iss to support a new URL query parameter, metrics-destination. For example: https://user:password@logs.herokai.com/logs?metric-destinations=argus,librato


<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
This query parameter should be parsed, and if present, metadata indicating its value should be added to each event in a format suitable to parsing by syslog-ng or any other regex processing routine.
<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
- [x] Passes `go test` testers
- [ ] Deploy to staging and test on real traffic
<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference

<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
