### PR TITLE
Add log-destination support

### DIFF
--- a/cmd/forwarder/config.go
+++ b/cmd/forwarder/config.go
@@ -28,6 +28,7 @@ type IssConfig struct {
 	MetadataId                string        `env:"METADATA_ID"`
 	Debug                     bool          `env:"LOG_ISS_DEBUG"`
 	QueryFieldParams          []string      `env:"LOG_ISS_FIELD_PARAMS"`
+	QueryParams               []string      `env:"LOG_ISS_QUERY_PARAMS"`
 	TlsConfig                 *tls.Config
 	MetricsRegistry           metrics.Registry
 }

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -23,11 +23,12 @@ const (
 )
 
 var nilVal = []byte("- ")
-var queryParams = []string{"index", "source", "sourcetype", "metrics-destination", "log-destination"}
+
+//var queryParams = []string{"index", "source", "sourcetype", "metrics-destination", "log-destination"}
 
 // Get metadata from the http request.
 // Returns an empty byte array if there isn't any.
-func getMetadata(req *http.Request, cred *credential, metadataId string, queryFieldParams []string) (string, bool) {
+func getMetadata(req *http.Request, cred *credential, metadataId string, config *IssConfig) (string, bool) {
 	var metadataWriter strings.Builder
 	var foundMetadata bool
 
@@ -42,10 +43,10 @@ func getMetadata(req *http.Request, cred *credential, metadataId string, queryFi
 		metadataWriter.WriteString("[")
 		metadataWriter.WriteString(metadataId)
 
-		for _, k := range append(queryParams, queryFieldParams...) {
+		for _, k := range append(config.QueryParams, config.QueryFieldParams...) {
 			v := req.FormValue(k)
 			if v != "" {
-				if containsString(queryFieldParams, k) {
+				if containsString(config.QueryFieldParams, k) {
 					if fieldsBuilder.Len() > 0 {
 						fieldsBuilder.WriteString(",")
 					}
@@ -115,11 +116,11 @@ type fixResult struct {
 // * integer representing the number of logplex frames parsed from the HTTP request.
 // * byte array of syslog data.
 // * error if something went wrong.
-func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken string, metadataId string, cred *credential, queryFieldParams []string) (fixResult, error) {
+func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken string, metadataId string, cred *credential, config *IssConfig) (fixResult, error) {
 	var messageWriter bytes.Buffer
 	var messageLenWriter bytes.Buffer
 
-	metadataString, hasMetadata := getMetadata(req, cred, metadataId, queryFieldParams)
+	metadataString, hasMetadata := getMetadata(req, cred, metadataId, config)
 
 	lp := lpx.NewReader(bufio.NewReader(r))
 	numLogs := int64(0)

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -23,7 +23,7 @@ const (
 )
 
 var nilVal = []byte("- ")
-var queryParams = []string{"index", "source", "sourcetype", "metrics-destination"}
+var queryParams = []string{"index", "source", "sourcetype", "metrics-destination", "log-destination"}
 
 // Get metadata from the http request.
 // Returns an empty byte array if there isn't any.

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -144,7 +144,18 @@ func TestFixWithMetricsDestination(t *testing.T) {
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
 	assert.Equal(r.numLogs, int64(2))
+}
 
+func TestFixWithLogDestination(t *testing.T) {
+	assert := assert.New(t)
+	var output = []byte("160 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" log-destination=\"hs,mcs\"] hi\n163 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" log-destination=\"hs,mcs\"] hello\n")
+
+	in := input[0]
+	r, _ := fix(httpRequestWithLogDestination(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, nil)
+
+	assert.Equal(string(output), string(r.bytes))
+	assert.True(r.hasMetadata)
+	assert.Equal(r.numLogs, int64(2))
 }
 
 func TestFixWithDeprecatedCredential(t *testing.T) {
@@ -223,6 +234,11 @@ func httpRequestWithCustomParams() *http.Request {
 
 func httpRequestWithMetricsDestination() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&metrics-destination=argus,librato", nil)
+	return req
+}
+
+func httpRequestWithLogDestination() *http.Request {
+	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&log-destination=hs,mcs", nil)
 	return req
 }
 

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestFix(t *testing.T) {
 	}
 
 	for x, in := range input {
-		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "", nil, make([]string, 0))
+		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", "", "", nil, getConfig())
 		assert.Equal(string(output[x]), string(r.bytes))
 		assert.False(r.hasMetadata)
 	}
@@ -86,7 +87,7 @@ func TestTruncationOfFields(t *testing.T) {
 
 	for _, i := range tests {
 		t.Run(i.name, func(t *testing.T) {
-			r, err := fix(simpleHttpRequest(), bytes.NewReader(i.bytes), "", "", "", nil, make([]string, 0))
+			r, err := fix(simpleHttpRequest(), bytes.NewReader(i.bytes), "", "", "", nil, getConfig())
 			assert.Equal(i.err, err)
 			assert.Equal(i.expected, r)
 		})
@@ -97,61 +98,41 @@ func TestFixWithQueryParameters(t *testing.T) {
 	assert := assert.New(t)
 	var output = []byte("135 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hi\n138 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\"] hello\n")
 
+	os.Setenv("LOG_ISS_QUERY_PARAMS", "index;source;sourcetype")
+
 	in := input[0]
-	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, make([]string, 0))
+	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, getConfig())
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
 	assert.Equal(int64(2), r.numLogs)
 }
 
-func TestFixWithCustomQueryParameters(t *testing.T) {
+func TestFixWithFieldParameters(t *testing.T) {
 	assert := assert.New(t)
 	var output = []byte("216 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2,credential_deprecated=true,credential_name=cred\"] hi\n219 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2,credential_deprecated=true,credential_name=cred\"] hello\n")
 
-	customQueryParams := []string{"custom1", "custom2"}
+	os.Setenv("LOG_ISS_QUERY_PARAMS", "index;source;sourcetype")
+	os.Setenv("LOG_ISS_FIELD_PARAMS", "custom1;custom2")
 
 	in := input[0]
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
-	r, _ := fix(httpRequestWithCustomParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, customQueryParams)
+	r, _ := fix(httpRequestWithFieldParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, getConfig())
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
 	assert.Equal(r.numLogs, int64(2))
 }
 
-func TestFixWithCustomQueryParametersNoCreds(t *testing.T) {
+func TestFixWithFieldParametersNoCreds(t *testing.T) {
 	assert := assert.New(t)
 	var output = []byte("168 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2\"] hi\n171 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" fields=\"custom1=cq1,custom2=cq2\"] hello\n")
 
-	customQueryParams := []string{"custom1", "custom2"}
+	os.Setenv("LOG_ISS_QUERY_PARAMS", "index;source;sourcetype")
+	os.Setenv("LOG_ISS_FIELD_PARAMS", "custom1;custom2")
 
 	in := input[0]
-	r, _ := fix(httpRequestWithCustomParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, customQueryParams)
-
-	assert.Equal(string(output), string(r.bytes))
-	assert.True(r.hasMetadata)
-	assert.Equal(r.numLogs, int64(2))
-}
-
-func TestFixWithMetricsDestination(t *testing.T) {
-	assert := assert.New(t)
-	var output = []byte("171 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" metrics-destination=\"argus,librato\"] hi\n174 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" metrics-destination=\"argus,librato\"] hello\n")
-
-	in := input[0]
-	r, _ := fix(httpRequestWithMetricsDestination(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, nil)
-
-	assert.Equal(string(output), string(r.bytes))
-	assert.True(r.hasMetadata)
-	assert.Equal(r.numLogs, int64(2))
-}
-
-func TestFixWithLogDestination(t *testing.T) {
-	assert := assert.New(t)
-	var output = []byte("160 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" log-destination=\"hs,mcs\"] hi\n163 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][metadata@123 index=\"i\" source=\"s\" sourcetype=\"st\" log-destination=\"hs,mcs\"] hello\n")
-
-	in := input[0]
-	r, _ := fix(httpRequestWithLogDestination(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, nil)
+	r, _ := fix(httpRequestWithFieldParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", nil, getConfig())
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
@@ -164,7 +145,7 @@ func TestFixWithDeprecatedCredential(t *testing.T) {
 
 	in := input[0]
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
-	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, make([]string, 0))
+	r, _ := fix(httpRequestWithParams(), bytes.NewReader(in), "1.2.3.4", "", "metadata@123", &cred, getConfig())
 
 	assert.Equal(string(output), string(r.bytes))
 	assert.True(r.hasMetadata)
@@ -183,7 +164,7 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 		[]byte("152 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
-		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "", nil, make([]string, 0))
+		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "", nil, getConfig())
 		assert.Equal(string(output[x]), string(r.bytes))
 		assert.False(r.hasMetadata)
 	}
@@ -191,14 +172,14 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 
 func BenchmarkGetMetadata(b *testing.B) {
 	input := []byte("106 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n")
-	customQueryParams := []string{"custom1", "custom2"}
+	os.Setenv("LOG_ISS_FIELD_PARAMS", "custom1;custom2")
 	cred := credential{Stage: "previous", Name: "cred", Deprecated: true}
 
 	b.SetBytes(int64(len(input)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(httpRequestWithCustomParams(), bytes.NewReader(input), "1.2.3.4", "", "metadata@123", &cred, customQueryParams)
+		fix(httpRequestWithFieldParams(), bytes.NewReader(input), "1.2.3.4", "", "metadata@123", &cred, getConfig())
 	}
 }
 
@@ -208,7 +189,7 @@ func BenchmarkFixNoSD(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, getConfig())
 	}
 }
 
@@ -218,7 +199,7 @@ func BenchmarkFixSD(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, make([]string, 0))
+		fix(simpleHttpRequest(), bytes.NewReader(input), "1.2.3.4", "", "", nil, getConfig())
 	}
 }
 
@@ -227,22 +208,22 @@ func httpRequestWithParams() *http.Request {
 	return req
 }
 
-func httpRequestWithCustomParams() *http.Request {
+func httpRequestWithFieldParams() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&custom1=cq1&custom2=cq2", nil)
-	return req
-}
-
-func httpRequestWithMetricsDestination() *http.Request {
-	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&metrics-destination=argus,librato", nil)
-	return req
-}
-
-func httpRequestWithLogDestination() *http.Request {
-	req, _ := http.NewRequest("POST", "/logs?index=i&source=s&sourcetype=st&log-destination=hs,mcs", nil)
 	return req
 }
 
 func simpleHttpRequest() *http.Request {
 	req, _ := http.NewRequest("POST", "/logs", nil)
 	return req
+}
+
+func getConfig() *IssConfig {
+	os.Setenv("DEPLOY", "codetest")
+	os.Setenv("FORWARD_DEST", "127.0.0.1:5001")
+	os.Setenv("PORT", "8080")
+
+	config, _ := NewIssConfig()
+
+	return &config
 }

--- a/cmd/forwarder/http.go
+++ b/cmd/forwarder/http.go
@@ -42,7 +42,7 @@ func NewPayload(sa string, ri string, b []byte) payload {
 //  * boolean - indicating whether the request has query params (aka metadata).
 //  * int64  - number of log lines read from the stream
 //  * error - if something went wrong.
-type FixerFunc func(*http.Request, io.Reader, string, string, string, *credential, []string) (fixResult, error)
+type FixerFunc func(*http.Request, io.Reader, string, string, string, *credential, *IssConfig) (fixResult, error)
 
 type httpServer struct {
 	Config                IssConfig
@@ -220,7 +220,7 @@ func (s *httpServer) process(req *http.Request, reader io.Reader, remoteAddr str
 	s.Add(1)
 	defer s.Done()
 
-	r, err := s.FixerFunc(req, reader, remoteAddr, logplexDrainToken, metadataId, cred, s.Config.QueryFieldParams)
+	r, err := s.FixerFunc(req, reader, remoteAddr, logplexDrainToken, metadataId, cred, &s.Config)
 	if err != nil {
 		return errors.New("Problem fixing body: " + err.Error()), http.StatusBadRequest
 	}


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
Heroku needs the ability to route logs based on a query parameter.
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
Add code to parse query and field parameters and add metadata to events that can be used later to direct the events appropriately.

<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
- [x] Passes unit tests
- [ ] Deploy to staging and verify that the require parameter shows up

<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference

<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
