### PR TITLE
Put a space before start of message

### DIFF
--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -172,7 +172,6 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		if len(b) >= 2 && bytes.Equal(b[0:2], nilVal) {
 			messageWriter.Write(b[1:])
 		} else if len(b) > 0 {
-			messageWriter.WriteString(" ARGH ")
 			messageWriter.Write(b)
 		}
 

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -172,6 +172,7 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		if len(b) >= 2 && bytes.Equal(b[0:2], nilVal) {
 			messageWriter.Write(b[1:])
 		} else if len(b) > 0 {
+			messageWriter.WriteString(" ")
 			messageWriter.Write(b)
 		}
 

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -172,9 +172,7 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		if len(b) >= 2 && bytes.Equal(b[0:2], nilVal) {
 			messageWriter.Write(b[1:])
 		} else if len(b) > 0 {
-			if b[0] != '[' {
-				messageWriter.WriteString(" ")
-			}
+			messageWriter.WriteString(" ")
 			messageWriter.Write(b)
 		}
 

--- a/cmd/forwarder/fixer.go
+++ b/cmd/forwarder/fixer.go
@@ -172,7 +172,7 @@ func fix(req *http.Request, r io.Reader, remoteAddr string, logplexDrainToken st
 		if len(b) >= 2 && bytes.Equal(b[0:2], nilVal) {
 			messageWriter.Write(b[1:])
 		} else if len(b) > 0 {
-			messageWriter.WriteString(" ")
+			messageWriter.WriteString(" ARGH ")
 			messageWriter.Write(b)
 		}
 

--- a/cmd/forwarder/fixer_test.go
+++ b/cmd/forwarder/fixer_test.go
@@ -25,10 +25,10 @@ func TestFix(t *testing.T) {
 	assert := assert.New(t)
 	var output = [][]byte{
 		[]byte("84 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hi\n87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
-		[]byte("127 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("128 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
 		[]byte("87 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
 		[]byte("80 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"]"),
-		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
+		[]byte("119 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - [origin ip=\"1.2.3.4\"] [60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 
 	for x, in := range input {
@@ -158,10 +158,10 @@ func TestFixWithLogplexDrainToken(t *testing.T) {
 
 	output := [][]byte{
 		[]byte("118 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hi\n121 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
-		[]byte("161 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"][meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
+		[]byte("162 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] [meta sequenceId=\"hello\"][foo bar=\"baz\"] hello\n"),
 		[]byte("121 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] hello\n"),
 		[]byte("114 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"]"),
-		[]byte("152 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"][60607e20-f12d-483e-aa89-ffaf954e7527]"),
+		[]byte("153 <13>1 2013-06-07T13:17:49.468822+00:00 d.34bc219c-983b-463e-a17d-3d34ee7db812 heroku web.7 - [origin ip=\"1.2.3.4\"] [60607e20-f12d-483e-aa89-ffaf954e7527]"),
 	}
 	for x, in := range input {
 		r, _ := fix(simpleHttpRequest(), bytes.NewReader(in), "1.2.3.4", testToken, "", nil, getConfig())


### PR DESCRIPTION
# Context

The `vaas` team has apps that emit logs that start with square-bracketed values. eg:

> [2021-04-14 18:37:00,748: INFO/ForkPoolWorker-2] Task core.tasks.check_verification_engine_health[64064b46-f9a7-48f2-ad3e-3ff5fb9b6bf4] succeeded in 0.7227490110090002s: None

log-iss is emitting these as `syslog` events. However, the events are malformed, and it looks like *any* logs that start with square-bracketed values are rejected. I believe that the events are malformed because there is no space in between the *actual* structured data fields and the body of the log. This results in downstream systems (syslog-ng, in our case) attempting to interpret these square-bracketed values as `SD-ELEMENT`s, and failing because they are not allowed structured data fields (only certain values are allowed for these fields). 

See https://tools.ietf.org/html/rfc5424#section-6.3 

# Solution

Put in a space  between the last `SD-ELEMENT` and the start of the event.

# Testing

- [x] spec tests
- [x] staging 

# Reference

https://heroku.support/980563