### PR TITLE
Remove usage of legacy codon-buildpacks buildpack URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ echo "64 <13>1 2013-06-07T13:17:49.468822+00:00 host heroku web.7 - - hi" | cu
 
 ```bash
 $ DEPLOY=`whoami`
-$ heroku create log-iss-$DEPLOY -r $DEPLOY --buildpack https://codon-buildpacks.s3.amazonaws.com/buildpacks/kr/go.tgz
+$ heroku create log-iss-$DEPLOY -r $DEPLOY --buildpack heroku/go
 $ heroku config:set -r $DEPLOY DEPLOY=$DEPLOY ENFORCE_SSL=1 FORWARD_DEST=my-syslog-host.com:601 TOKEN_MAP=syslog:$(openssl rand -hex 20)
 $ heroku labs:enable -r $DEPLOY http-request-id
 $ heroku labs:enable -r $DEPLOY log-runtime-metrics


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

With this change, the docs now say to use the official Heroku Go buildpack rather than a third-party's from a legacy S3 bucket.

GUS-W-10034067. 