### PR TITLE
update GHA runner for public repo

### DIFF
--- a/.github/workflows/workflow-to-workflow.yml
+++ b/.github/workflows/workflow-to-workflow.yml
@@ -17,7 +17,7 @@ on:
       - 'components-info/*.json'
 jobs:
   action: 
-    runs-on: sfdc-hk-ubuntu-latest
+    runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - uses : actions/checkout@v3
       - name: Workflow


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
We have to update GHA runner as its public repo
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

